### PR TITLE
added time range validation with --start-time and --end-time args

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A smarter SMB password sprayer with customizable options
 ```
 SMBSpray v1.2
 
-usage: smbspray.py [-h] [-u users] [-U user] [-p passwords] [-P password] [-d domain] [-l minutes] [-a attempts] -ip IP/hostname [--threads threads] [--verbose] [--user_pw] [--unsafe] [--no-interaction]
+usage: smbspray.py [-h] [-u users] [-U user] [-p passwords] [-P password] [-d domain] [-l minutes] [-a attempts] -ip IP/hostname [--threads threads] [--verbose] [--user_pw] [--unsafe] [--no-interaction] [--start-time HH:MM] [--end-time HH:MM]
 
 Parse Spray Arguments.
 
@@ -25,6 +25,8 @@ optional arguments:
   --user_pw          Try username variations as password
   --unsafe           Keep spraying even if there are multiple account lockouts
   --no-interaction   Do not ask for user input
+  --start-time HH:MM Start time for allowed operation
+  --end-time HH:MM   End time for allowed operation
   ```
 
 


### PR DESCRIPTION
smbspray already offers functionalities to avoid the blocking of accounts. But sometimes you have to assume the biggest idiot in front of the computer. so if i automatically tried the password of a user 5 times and the user then mistyped it twice, the account was blocked. that's why i introduced two arguments. so you can set the start and end time of the scan. i can start a scan and it only starts at night and ends before a normal user goes about their daily business. When it gets night again, smbspray continues scanning.